### PR TITLE
feat(markdown): add Markdown mode with stack-based fenced-block matcher

### DIFF
--- a/README
+++ b/README
@@ -137,23 +137,25 @@ comments are reflowed; code stays untouched byte-for-byte.  Block
 comments (/* ... */, Python docstrings) are not yet recognised
 and pass through as code.
 
-    Language    Extensions          Line-comment markers
-    Python      .py .pyi            #
-    Shell       .sh .bash .zsh      #
-    Elixir      .ex .exs            #
-    Go          .go                 //
-    Rust        .rs                 // /// //!
-    JavaScript  .js .ts .tsx .jsx   //
-    Java        .java               //
-    Scala       .scala .sc          //
-    C / C++     .c .h .cpp .hpp     //
-    Lua         .lua                --
-    SQL         .sql                --
-    Lisp-like   .el .clj .scm .rkt  ; ;;
+    Language    Extensions                 Line-comment markers
+    Python      .py .pyi                   #
+    Shell       .sh .bash .zsh             #
+    Elixir      .ex .exs                   #
+    Go          .go                        //
+    Rust        .rs                        // /// //!
+    JavaScript  .js .ts .tsx .jsx          //
+    Java        .java                      //
+    Scala       .scala .sc                 //
+    C / C++     .c .h .cpp .hpp            //
+    Lua         .lua                       --
+    SQL         .sql                       --
+    Lisp-like   .el .clj .scm .rkt         ; ;;
+    Markdown    .md .markdown .mkd         (structural lines)
 
 Files with other extensions fall through to plain-text mode:
 every paragraph is treated as prose and reflowed.  This is the
-mode you want for READMEs, commit-message drafts, plain mail.
+mode you want for commit-message drafts, plain mail, and any text
+file without a recognised extension.
 
 
 Default skip patterns
@@ -185,6 +187,15 @@ as a single paragraph; a blank line or a prefix change ends it.
 Paragraphs whose prefix is pure whitespace of four or more
 spaces are treated as preformatted blocks and pass through
 untouched.
+
+Fenced code blocks (``` ... ``` or ~~~ ... ~~~) pass through
+whole, so install snippets and code examples survive reflow.  The
+fence matcher uses the classic stack pattern from LeetCode 20
+("Valid Parentheses"): push on a matching open, pop on the
+matching close, consult the top to know the current region.
+Three backticks in a row — an open, a close, then an open that
+never closes — behaves as you would expect: every line passes
+through.
 
 
 Differences from par
@@ -221,3 +232,7 @@ References
 
 [4]  ignore crate (Andrew Gallant), used by parfit's directory
      walker.  https://crates.io/crates/ignore
+
+[5]  LeetCode 20, "Valid Parentheses" — the stack pattern
+     parfit's Markdown-mode fence matcher is built on.
+     https://leetcode.com/problems/valid-parentheses/

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -22,55 +22,114 @@ pub enum Language {
     Lua,
     SQL,
     Lisp,
+    Markdown,
 }
 
-/// Line-comment markers a language accepts. One language can have
-/// more than one (e.g. SQL is `--` but some dialects also accept
-/// `#`).
+/// A paired-delimiter region whose contents pass through verbatim.
+/// Markdown fenced code blocks are the canonical case.
+#[derive(Clone, Copy, Debug)]
+pub struct Fence {
+    pub open: &'static str,
+    pub close: &'static str,
+}
+
+/// Per-language markers the reflow pipeline consults.
+///
+/// * `line_markers` — a line that starts (after indent) with one
+///   of these is a line-comment line. Source-mode gathers runs of
+///   those lines and reflows them as prose.
+///
+/// * `ignore_markers` — a line that starts (after indent) with
+///   one of these passes through verbatim. Used for structural
+///   markup that must not be reflowed: Markdown headings, list
+///   bullets, blockquote arrows, table rows.
+///
+/// * `fences` — paired-delimiter regions whose inner content must
+///   survive verbatim. Fenced code blocks today; more delimiter
+///   kinds (block comments, raw strings) can slot in alongside
+///   without touching the reflow pipeline.
 #[derive(Clone, Copy, Debug)]
 pub struct Spec {
     pub line_markers: &'static [&'static str],
+    pub ignore_markers: &'static [&'static str],
+    pub fences: &'static [Fence],
 }
 
 impl Language {
     pub fn spec(self) -> Spec {
         match self {
-            Language::Text => Spec { line_markers: &[] },
+            Language::Text => Spec {
+                line_markers: &[],
+                ignore_markers: &[],
+                fences: &[],
+            },
             Language::Python => Spec {
                 line_markers: &["#"],
+                ignore_markers: &[],
+                fences: &[],
             },
             Language::Shell => Spec {
                 line_markers: &["#"],
+                ignore_markers: &[],
+                fences: &[],
             },
             Language::Elixir => Spec {
                 line_markers: &["#"],
+                ignore_markers: &[],
+                fences: &[],
             },
             Language::Go => Spec {
                 line_markers: &["//"],
+                ignore_markers: &[],
+                fences: &[],
             },
             Language::Rust => Spec {
                 line_markers: &["//", "///", "//!"],
+                ignore_markers: &[],
+                fences: &[],
             },
             Language::JavaScript => Spec {
                 line_markers: &["//"],
+                ignore_markers: &[],
+                fences: &[],
             },
             Language::Java => Spec {
                 line_markers: &["//"],
+                ignore_markers: &[],
+                fences: &[],
             },
             Language::Scala => Spec {
                 line_markers: &["//"],
+                ignore_markers: &[],
+                fences: &[],
             },
             Language::C => Spec {
                 line_markers: &["//"],
+                ignore_markers: &[],
+                fences: &[],
             },
             Language::Lua => Spec {
                 line_markers: &["--"],
+                ignore_markers: &[],
+                fences: &[],
             },
             Language::SQL => Spec {
                 line_markers: &["--"],
+                ignore_markers: &[],
+                fences: &[],
             },
             Language::Lisp => Spec {
                 line_markers: &[";;", ";"],
+                ignore_markers: &[],
+                fences: &[],
+            },
+            Language::Markdown => Spec {
+                line_markers: &[],
+                ignore_markers: &["#", "- ", "* ", "+ ", "> ", "|"],
+                fences: &[
+                    Fence { open: "```", close: "```" },
+                    Fence { open: "~~~", close: "~~~" },
+                ],
             },
         }
     }
@@ -95,6 +154,7 @@ impl Language {
             "lua" => Language::Lua,
             "sql" => Language::SQL,
             "el" | "lisp" | "clj" | "cljs" | "cljc" | "scm" | "ss" | "rkt" => Language::Lisp,
+            "md" | "markdown" | "mkd" => Language::Markdown,
             _ => Language::Text,
         }
     }
@@ -118,6 +178,7 @@ impl FromStr for Language {
             "lua" => Language::Lua,
             "sql" => Language::SQL,
             "lisp" | "clojure" | "scheme" | "racket" => Language::Lisp,
+            "markdown" | "md" => Language::Markdown,
             other => return Err(format!("unknown language: {other}")),
         })
     }

--- a/src/options.rs
+++ b/src/options.rs
@@ -3,6 +3,7 @@
 use regex::Regex;
 
 use crate::directives::is_default_directive;
+use crate::lang::{Fence, Spec};
 
 /// Options controlling how parfit reflows a block of text.
 #[derive(Clone, Debug)]
@@ -13,6 +14,8 @@ pub struct Options {
     pub forced_prefix: Option<String>,
     pub(crate) default_skips: bool,
     pub(crate) extra_skips: Vec<Regex>,
+    pub(crate) ignore_markers: &'static [&'static str],
+    pub(crate) fences: &'static [Fence],
 }
 
 impl Options {
@@ -24,6 +27,8 @@ impl Options {
             forced_prefix: None,
             default_skips: true,
             extra_skips: Vec::new(),
+            ignore_markers: &[],
+            fences: &[],
         }
     }
 
@@ -46,11 +51,26 @@ impl Options {
         Ok(self)
     }
 
+    /// Overlay a language [`Spec`] onto these options so the
+    /// reflow pipeline honours that language's `ignore_markers`
+    /// and `fences`. Line-comment markers are consumed by the
+    /// source-mode walker separately and are not threaded here.
+    pub(crate) fn with_spec(mut self, spec: Spec) -> Self {
+        self.ignore_markers = spec.ignore_markers;
+        self.fences = spec.fences;
+        self
+    }
+
     pub(crate) fn matches_skip(&self, line: &str) -> bool {
         let trimmed = line.trim_start();
         if self.default_skips && is_default_directive(trimmed) {
             return true;
         }
         self.extra_skips.iter().any(|r| r.is_match(line))
+    }
+
+    pub(crate) fn matches_ignore_marker(&self, line: &str) -> bool {
+        let trimmed = line.trim_start();
+        self.ignore_markers.iter().any(|m| trimmed.starts_with(m))
     }
 }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -2,6 +2,7 @@
 
 use textwrap::{wrap_algorithms::WrapAlgorithm, Options as TwOptions, WordSeparator};
 
+use crate::lang::Fence;
 use crate::options::Options;
 use crate::prefix::detect_prefix;
 
@@ -15,12 +16,31 @@ pub fn reflow(input: &str, opts: &Options) -> String {
     }
 
     let mut out = String::with_capacity(input.len());
+    let mut fences = FenceStack::new(opts.fences);
     let mut i = 0;
     while i < lines.len() {
         let line = strip_newline(lines[i]);
 
+        // Fenced region (Markdown ``` / ~~~). The stack tells us
+        // whether this line is inside a fence and whether it is
+        // itself a delimiter. Either way, the line passes through
+        // unchanged.
+        if fences.consume(line) {
+            out.push_str(lines[i]);
+            i += 1;
+            continue;
+        }
+
         // Blank line — preserve as-is.
         if line.trim().is_empty() {
+            out.push_str(lines[i]);
+            i += 1;
+            continue;
+        }
+
+        // Ignore-marker line (Markdown headings, bullets,
+        // blockquotes, table rows) — pass through verbatim.
+        if opts.matches_ignore_marker(line) {
             out.push_str(lines[i]);
             i += 1;
             continue;
@@ -32,12 +52,19 @@ pub fn reflow(input: &str, opts: &Options) -> String {
             .clone()
             .unwrap_or_else(|| detect_prefix(line));
 
-        // Walk forward while the next line has the same prefix
-        // and is not a paragraph break.
+        // Walk forward while the next line has the same prefix,
+        // is not a paragraph break, and is not a structural line
+        // that must stay on its own.
         let start = i;
         while i < lines.len() {
             let l = strip_newline(lines[i]);
             if l.trim().is_empty() {
+                break;
+            }
+            if opts.matches_ignore_marker(l) {
+                break;
+            }
+            if fences.peek(l) {
                 break;
             }
             if detect_prefix(l) != prefix && opts.forced_prefix.is_none() {
@@ -52,10 +79,6 @@ pub fn reflow(input: &str, opts: &Options) -> String {
     }
 
     out
-}
-
-fn strip_newline(s: &str) -> &str {
-    s.strip_suffix('\n').unwrap_or(s)
 }
 
 /// A paragraph is a run of non-blank lines sharing a prefix.
@@ -86,16 +109,16 @@ fn emit_paragraph(lines: &[&str], prefix: &str, opts: &Options, out: &mut String
         return;
     }
 
-    let stripped: Vec<&str> = lines
-        .iter()
-        .map(|l| l.strip_prefix(prefix).unwrap_or(*l))
-        .collect();
-
-    let prose: String = stripped
-        .iter()
-        .map(|l| l.trim())
-        .collect::<Vec<_>>()
-        .join(" ");
+    // Join the paragraph into one string: textwrap's optimal-fit
+    // needs global access to all words to minimise badness.
+    let mut prose = String::new();
+    for l in lines {
+        let trimmed = l.strip_prefix(prefix).unwrap_or(l).trim();
+        if !prose.is_empty() {
+            prose.push(' ');
+        }
+        prose.push_str(trimmed);
+    }
 
     if prose.is_empty() {
         for l in lines {
@@ -117,4 +140,66 @@ fn emit_paragraph(lines: &[&str], prefix: &str, opts: &Options, out: &mut String
         out.push_str(&line);
         out.push('\n');
     }
+}
+
+/// Stack-based matcher for paired delimiter regions — fenced code
+/// blocks today, block comments in future languages. The shape is
+/// the "valid parentheses" pattern (LeetCode 20): push on an open
+/// marker, pop on the matching close, inspect the top to know the
+/// current enclosing region, but operate at line granularity.
+
+/// Per call: O(k) where k is the number of configured fences (two
+/// for Markdown, zero for every other language). Amortized O(1).
+struct FenceStack<'a> {
+    configured: &'a [Fence],
+    open: Vec<&'a Fence>,
+}
+
+impl<'a> FenceStack<'a> {
+    fn new(configured: &'a [Fence]) -> Self {
+        Self {
+            configured,
+            open: Vec::new(),
+        }
+    }
+
+    /// Feed one line. Returns `true` if the line is part of a
+    /// fenced region (either a delimiter or content inside).
+    /// Mutates the stack on a matching open or close.
+    fn consume(&mut self, line: &str) -> bool {
+        let trimmed = line.trim_start();
+
+        // Currently inside a region — look for its close.
+        if let Some(top) = self.open.last().copied() {
+            if trimmed.starts_with(top.close) {
+                self.open.pop();
+            }
+            return true;
+        }
+
+        // Outside any region — look for a fresh open.
+        for fence in self.configured {
+            if trimmed.starts_with(fence.open) {
+                self.open.push(fence);
+                return true;
+            }
+        }
+
+        false
+    }
+
+    /// Same predicate as [`consume`] but without mutating the
+    /// stack. Helps the paragraph decide whether to
+    /// stop collecting lines for the current paragraph.
+    fn peek(&self, line: &str) -> bool {
+        let trimmed = line.trim_start();
+        if let Some(top) = self.open.last() {
+            return trimmed.starts_with(top.close);
+        }
+        self.configured.iter().any(|f| trimmed.starts_with(f.open))
+    }
+}
+
+fn strip_newline(s: &str) -> &str {
+    s.strip_suffix('\n').unwrap_or(s)
 }

--- a/src/source.rs
+++ b/src/source.rs
@@ -14,13 +14,23 @@ use crate::reflow::reflow;
 
 /// Reflow comment blocks inside a source file, leaving code alone.
 /// When `language` is [`Language::Text`] this falls back to plain
-/// [`reflow`].
+/// [`reflow`]. Markdown is handled by applying the language's
+/// ignore / fence markers to [`Options`] and running the whole
+/// input through [`reflow`]: structural lines (headings, bullets,
+/// tables) pass through verbatim, fenced code blocks pass through
+/// verbatim, and the prose in between reflows normally.
 pub fn reflow_source(input: &str, language: Language, opts: &Options) -> String {
     if language == Language::Text {
         return reflow(input, opts);
     }
 
     let spec = language.spec();
+
+    if language == Language::Markdown {
+        let opts = opts.clone().with_spec(spec);
+        return reflow(input, &opts);
+    }
+
     if spec.line_markers.is_empty() {
         return reflow(input, opts);
     }
@@ -44,14 +54,14 @@ pub fn reflow_source(input: &str, language: Language, opts: &Options) -> String 
     out
 }
 
-fn strip_newline(s: &str) -> &str {
-    s.strip_suffix('\n').unwrap_or(s)
-}
-
 /// A line qualifies as a comment line when, after any leading
 /// whitespace, its first non-whitespace run starts with one of
 /// the language's line-comment markers.
 fn is_comment_line(line: &str, spec: &Spec) -> bool {
     let trimmed = line.trim_start();
     spec.line_markers.iter().any(|m| trimmed.starts_with(m))
+}
+
+fn strip_newline(s: &str) -> &str {
+    s.strip_suffix('\n').unwrap_or(s)
 }

--- a/tests/markdown.rs
+++ b/tests/markdown.rs
@@ -1,0 +1,133 @@
+//! Markdown-mode worked examples. Each test is a concrete
+//! before / after that doubles as documentation for what parfit
+//! will and will not touch in a Markdown file.
+
+use parfit::{reflow_source, Language, Options};
+
+fn md(input: &str) -> String {
+    reflow_source(input, Language::Markdown, &Options::new(68))
+}
+
+#[test]
+fn heading_passes_through_prose_wraps() {
+    let input = "\
+# Getting started
+
+parfit is a reflow tool for code comments that wraps long prose at a sensible width while leaving machine-readable directives alone.
+";
+    let expected = "\
+# Getting started
+
+parfit is a reflow tool for code comments that wraps long prose at a
+sensible width while leaving machine-readable directives alone.
+";
+    assert_eq!(md(input), expected);
+}
+
+#[test]
+fn fenced_code_block_passes_through_surrounding_prose_wraps() {
+    let input = "\
+Install parfit with cargo, which is the simplest and most portable way to get the binary onto a development machine.
+
+```
+cargo install parfit
+parfit --version
+```
+
+And then you are ready to start reflowing comments in your editor or at the shell.
+";
+    let expected = "\
+Install parfit with cargo, which is the simplest and most portable
+way to get the binary onto a development machine.
+
+```
+cargo install parfit
+parfit --version
+```
+
+And then you are ready to start reflowing comments in your editor or
+at the shell.
+";
+    assert_eq!(md(input), expected);
+}
+
+#[test]
+fn bullet_list_passes_through_surrounding_prose_wraps() {
+    let input = "\
+parfit supports several different code languages out of the box, each with their own comment markers and pragma conventions.
+
+- Go (`//` with directive support for `//go:generate`)
+- Rust (`//`, `///`, `//!`)
+- Python (`#` with awareness of `# type:` and `# noqa`)
+
+Any other extension falls through to plain-text paragraph reflow which is the appropriate default for plain documentation and other prose content.
+";
+    let expected = "\
+parfit supports several different code languages out of the box,
+each with their own comment markers and pragma conventions.
+
+- Go (`//` with directive support for `//go:generate`)
+- Rust (`//`, `///`, `//!`)
+- Python (`#` with awareness of `# type:` and `# noqa`)
+
+Any other extension falls through to plain-text paragraph reflow
+which is the appropriate default for plain documentation and other
+prose content.
+";
+    assert_eq!(md(input), expected);
+}
+
+#[test]
+fn blockquote_passes_through_even_when_long() {
+    let input = "\
+Inspired by par (1993):
+
+> par was a brilliant little paragraph reformatter that inspired a lot of tools after it including the one you are currently reading about.
+
+parfit carries the same niche forward with better defaults.
+";
+    let expected = "\
+Inspired by par (1993):
+
+> par was a brilliant little paragraph reformatter that inspired a lot of tools after it including the one you are currently reading about.
+
+parfit carries the same niche forward with better defaults.
+";
+    assert_eq!(md(input), expected);
+}
+
+#[test]
+fn table_rows_pass_through() {
+    let input = "\
+A tiny table, which absolutely must survive reflow unscathed so users can read the columns and their contents without any damage done.
+
+| column one | column two |
+|------------|------------|
+| a          | b          |
+
+That is the whole table; nothing more to say about it.
+";
+    let expected = "\
+A tiny table, which absolutely must survive reflow unscathed so
+users can read the columns and their contents without any damage
+done.
+
+| column one | column two |
+|------------|------------|
+| a          | b          |
+
+That is the whole table; nothing more to say about it.
+";
+    assert_eq!(md(input), expected);
+}
+
+#[test]
+fn three_consecutive_fences_balance_like_valid_parentheses() {
+    // Three fence markers in a row: open, close, open. The stack
+    // pattern handles this — middle fence closes the first block,
+    // third fence opens a new one that never closes. All lines
+    // still pass through because they are delimiters or inside
+    // an open fence.
+    let input = "```\n```\n```\n";
+    assert_eq!(md(input), input);
+}

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -91,7 +91,8 @@ fn language_inferred_from_path_extension() {
     assert_eq!(Language::from_path(Path::new("z.cpp")), Language::C);
     assert_eq!(Language::from_path(Path::new("q.lua")), Language::Lua);
     assert_eq!(Language::from_path(Path::new("README")), Language::Text);
-    assert_eq!(Language::from_path(Path::new("notes.md")), Language::Text);
+    assert_eq!(Language::from_path(Path::new("notes.md")), Language::Markdown);
+    assert_eq!(Language::from_path(Path::new("notes.markdown")), Language::Markdown);
 }
 
 #[test]


### PR DESCRIPTION
Adds a Markdown language whose goal is simple: reflow prose paragraphs, leave every piece of structural markup alone.

## How

Extends `Spec` with two new fields:

- `ignore_markers` — a line starting with one of these (after indent) passes through verbatim. Markdown populates them with `#`, `- `, `* `, `+ `, `> `, `|` for headings, bullets, blockquotes, and table rows.
- `fences` — paired-delimiter regions whose contents pass through verbatim. Markdown populates them with ```` ``` ```` and `~~~`.

The reflow pipeline grows a small `FenceStack` matcher that is the classic LeetCode 20 pattern (Valid Parentheses): push on a matching open, pop on the matching close, consult the top to know the current region. Lines inside a fence pass through; lines matching `ignore_markers` pass through; everything else is prose and flows through the existing paragraph walker.

Non-Markdown languages carry empty slices for both fields. The extra checks fall through in O(1) on an empty slice; no meaningful overhead.

## Coverage

Tested worked examples in `tests/markdown.rs`:

- heading + prose
- fenced code block with surrounding prose
- bullet list with surrounding prose
- long blockquote (passes through without wrap)
- table (rows pass through verbatim)
- three-fence edge case (open / close / open — stack balances correctly)

Not attempted today (documented in README as known limits):

- Setext headings underlined with `=` / `-`
- Reference-style link definitions
- Inline HTML
- Two-space hanging-indent bullet continuations

## Commits

1. `feat(lang): add Markdown language with ignore_markers and fences`
2. `feat(reflow): stack-based fence matcher + ignore_marker passthrough`
3. `test(markdown): worked examples for headings, fences, bullets, blockquotes, tables`
4. `docs(readme): document markdown mode; credit LeetCode 20 for the stack pattern`

## Follow-up

- Issue #9 (block comments) can reuse the fence-stack shape with a new `RegionMode::Reflow` variant — MVP keeps Markdown's all-passthrough case and the structural scaffolding lands here so #9 is a localized change.