### PR TITLE
ci: GitHub Actions with release-plz and auto-FF of rel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [dev]
+  pull_request:
+
+jobs:
+  test:
+    name: test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --verbose
+      - run: cargo test --verbose
+
+  lint:
+    name: fmt + clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all -- --check
+      - run: cargo clippy --all-targets -- -D warnings

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: Release
+
+on:
+  push:
+    branches: [dev]
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release-pr:
+    name: Open release PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: release-plz/action@v0.5
+        id: release
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      - name: Fast-forward rel to the released commit
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        run: git push origin HEAD:rel

--- a/CONTRIBUTING
+++ b/CONTRIBUTING
@@ -1,0 +1,16 @@
+parfit - contributing
+=====================
+
+Semantic commits.  Use Conventional Commits — feat:, fix:, docs:,
+ci:, test:, refactor:, style:, chore: — so the log reads as a
+changelog without further processing.
+
+Releases are automatic.  release-plz watches dev, reads the
+commits since the last tag, and opens a "Release vX.Y.Z" PR that
+bumps Cargo.toml and updates CHANGELOG.md.  Merging that PR
+publishes to crates.io, tags the commit, and opens a GitHub
+release.
+
+rel tracks the last release.  The release workflow fast-forwards
+the rel branch to whatever commit was just released, so rel is a
+pointer to the current published version and never leads dev.

--- a/src/directives.rs
+++ b/src/directives.rs
@@ -26,10 +26,7 @@ pub(crate) fn is_default_directive(line: &str) -> bool {
     }
 
     // Python pragmas and noqa markers.
-    if line.starts_with("# type:")
-        || line.starts_with("# noqa")
-        || line.starts_with("# pragma:")
-    {
+    if line.starts_with("# type:") || line.starts_with("# noqa") || line.starts_with("# pragma:") {
         return true;
     }
 
@@ -52,7 +49,11 @@ pub(crate) fn is_default_directive(line: &str) -> bool {
     }
 
     // Separator lines inside comments ("// ----" etc.).
-    if line.chars().all(|c| "-=*_".contains(c) || c.is_whitespace()) && !line.trim().is_empty() {
+    if line
+        .chars()
+        .all(|c| "-=*_".contains(c) || c.is_whitespace())
+        && !line.trim().is_empty()
+    {
         return true;
     }
 

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -45,8 +45,7 @@ pub fn walk(
 
         let walker = WalkBuilder::new(path).build();
         for entry in walker {
-            let entry = entry
-                .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+            let entry = entry.map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
             if !entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
                 continue;
             }
@@ -66,8 +65,8 @@ fn build_globset(patterns: &[String]) -> io::Result<Option<GlobSet>> {
     }
     let mut builder = GlobSetBuilder::new();
     for p in patterns {
-        let glob = Glob::new(p)
-            .map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
+        let glob =
+            Glob::new(p).map_err(|e| io::Error::new(io::ErrorKind::InvalidInput, e.to_string()))?;
         builder.add(glob);
     }
     builder

--- a/src/walker.rs
+++ b/src/walker.rs
@@ -45,7 +45,7 @@ pub fn walk(
 
         let walker = WalkBuilder::new(path).build();
         for entry in walker {
-            let entry = entry.map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+            let entry = entry.map_err(|e| io::Error::other(e.to_string()))?;
             if !entry.file_type().map(|ft| ft.is_file()).unwrap_or(false) {
                 continue;
             }

--- a/tests/examples.rs
+++ b/tests/examples.rs
@@ -124,7 +124,10 @@ func Foo() int {
     return 42
 }
 ";
-    assert_eq!(reflow_source(input, Language::Go, &Options::new(68)), expected);
+    assert_eq!(
+        reflow_source(input, Language::Go, &Options::new(68)),
+        expected
+    );
 }
 
 #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -46,7 +46,8 @@ fn leaves_ts_ignore_directive_untouched() {
 
 #[test]
 fn custom_skip_regex_passes_line_through() {
-    let input = "// TODO(cal): this is a very long line that normally would be wrapped at thirty cols\n";
+    let input =
+        "// TODO(cal): this is a very long line that normally would be wrapped at thirty cols\n";
     let opts = Options::new(30).with_skip(r"TODO\(").unwrap();
     assert_eq!(reflow(input, &opts), input);
 }
@@ -77,7 +78,8 @@ fn preserves_exact_url_body() {
 
 #[test]
 fn hash_prefix_shell_style() {
-    let input = "# this is a shell comment that is long enough to need wrapping at a sensible width\n";
+    let input =
+        "# this is a shell comment that is long enough to need wrapping at a sensible width\n";
     let out = reflow(input, &Options::new(40));
     for line in out.lines() {
         assert!(line.starts_with("# "));

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -14,7 +14,9 @@ def f():
     assert!(out.contains("    x = 42\n"));
     assert!(out.contains("    return x\n"));
     // Comment was wrapped.
-    assert!(!out.contains("this is a really long comment that ought to be reflowed at a narrow width"));
+    assert!(
+        !out.contains("this is a really long comment that ought to be reflowed at a narrow width")
+    );
     for line in out.lines() {
         if line.trim_start().starts_with('#') {
             assert!(line.chars().count() <= 32, "wrapped line too long: {line}");


### PR DESCRIPTION
## Summary

- Adds CI workflow (build/test on Linux+macOS+Windows, plus fmt + clippy gates).
- Adds release-plz workflow: opens release PRs on dev, publishes on merge, fast-forwards rel to the released commit.
- Applies cargo fmt to bring the repo into line with the new fmt gate.
- Adds CONTRIBUTING describing the commit style and release flow.

## Release flow

1. Push conventional commits to dev.
2. release-plz opens / updates a "Release vX.Y.Z" PR with the Cargo.toml bump and CHANGELOG entry.
3. Merge that PR. release-plz publishes to crates.io, tags, opens the GitHub Release, and the final workflow step fast-forwards rel to that commit. rel never leads dev.

## Prerequisite

Add a CARGO_REGISTRY_TOKEN secret before the first release merge.

## Test plan

- [ ] CI runs green on this PR
- [ ] After merge, release-plz opens a release PR on dev
- [ ] Merging the release PR publishes to crates.io and fast-forwards rel