### PR TITLE
ci: mirror pushes to sr.ht

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -1,0 +1,30 @@
+name: Mirror to sr.ht
+
+on:
+  push:
+    branches: ['**']
+    tags: ['**']
+
+concurrency:
+  group: mirror-srht
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Mirror to sr.ht
+        env:
+          SRHT_SSH_KEY: ${{ secrets.SRHT_SSH_KEY }}
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          ssh-keyscan -t ed25519 git.sr.ht >> ~/.ssh/known_hosts
+          eval "$(ssh-agent -s)"
+          ssh-add - <<< "$SRHT_SSH_KEY"
+          git remote add srht git@git.sr.ht:~caldempsey/parfit
+          git push --mirror srht
+          ssh-add -D
+          kill "$SSH_AGENT_PID"


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that pushes every branch and tag update to the SourceHut mirror at https://git.sr.ht/~caldempsey/parfit on each push.

Uses `git push --mirror`, so the sr.ht repo becomes a bit-for-bit copy: branches added here appear there, branches deleted here are deleted there. No merge logic, no drift.

## Prerequisite

Before this workflow can succeed:

1. Create an empty repository at https://git.sr.ht/~caldempsey/parfit (a bare push target — no initial commit needed).
2. Generate an SSH keypair dedicated to this mirror (\`ssh-keygen -t ed25519 -f srht-mirror -N ""\`).
3. Add the public key (\`srht-mirror.pub\`) to your sr.ht SSH keys at https://meta.sr.ht/keys.
4. Add the private key (\`srht-mirror\`) as a repo secret named \`SRHT_SSH_KEY\` in this GitHub repo's Settings -> Secrets -> Actions.

## Test plan

- [ ] After merging, push anything to dev and watch the Mirror workflow succeed.
- [ ] \`git clone git@git.sr.ht:~caldempsey/parfit\` reflects the GitHub repo.