### PR TITLE
feat(source): block-comment support (closes #9)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,3 @@
+#!/bin/sh
+set -e
+cargo fmt --all -- --check

--- a/README
+++ b/README
@@ -207,9 +207,16 @@ whole, so install snippets and code examples survive reflow.  The
 fence matcher uses the classic stack pattern from LeetCode 20
 ("Valid Parentheses"): push on a matching open, pop on the
 matching close, consult the top to know the current region.
-Three backticks in a row — an open, a close, then an open that
-never closes — behaves as you would expect: every line passes
-through.
+
+Block comments (`/* … */`) are just the inverse: the contents
+reflow as prose instead of passing through.
+
+Under the hood, the four per-language markers sit on a 2×2:
+
+                 | reflow contents | pass through verbatim
+    -------------|-----------------|----------------------
+    line-level   | line_markers    | ignore_markers
+    region-level | block_comments  | fences
 
 
 Differences from par

--- a/src/lang.rs
+++ b/src/lang.rs
@@ -25,8 +25,11 @@ pub enum Language {
     Markdown,
 }
 
-/// A paired-delimiter region whose contents pass through verbatim.
-/// Markdown fenced code blocks are the canonical case.
+/// A paired-delimiter region: an `open` string and a matching
+/// `close`.  Used in [`Spec`] for two opposite purposes — Markdown
+/// code fences (pass the contents through verbatim) and C-family
+/// block comments (reflow the contents as prose).  The field name
+/// in [`Spec`] picks the treatment; the shape is identical.
 #[derive(Clone, Copy, Debug)]
 pub struct Fence {
     pub open: &'static str,
@@ -44,15 +47,22 @@ pub struct Fence {
 ///   markup that must not be reflowed: Markdown headings, list
 ///   bullets, blockquote arrows, table rows.
 ///
-/// * `fences` — paired-delimiter regions whose inner content must
-///   survive verbatim. Fenced code blocks today; more delimiter
-///   kinds (block comments, raw strings) can slot in alongside
-///   without touching the reflow pipeline.
+/// * `fences` — paired-delimiter regions whose contents pass
+///   through verbatim.  Markdown code fences today; raw-string
+///   literals in future languages slot in alongside without
+///   touching the reflow pipeline.
+///
+/// * `block_comments` — paired-delimiter regions whose contents
+///   are prose and reflow.  The inverse of `fences`: same type,
+///   opposite treatment — `fences` preserve contents byte-for-
+///   byte, `block_comments` feed contents to the reflow pipeline.
+///   C-family `/* … */` is the canonical case.
 #[derive(Clone, Copy, Debug)]
 pub struct Spec {
     pub line_markers: &'static [&'static str],
     pub ignore_markers: &'static [&'static str],
     pub fences: &'static [Fence],
+    pub block_comments: &'static [Fence],
 }
 
 impl Language {
@@ -62,74 +72,112 @@ impl Language {
                 line_markers: &[],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[],
             },
             Language::Python => Spec {
                 line_markers: &["#"],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[],
             },
             Language::Shell => Spec {
                 line_markers: &["#"],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[],
             },
             Language::Elixir => Spec {
                 line_markers: &["#"],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[],
             },
             Language::Go => Spec {
                 line_markers: &["//"],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[Fence {
+                    open: "/*",
+                    close: "*/",
+                }],
             },
             Language::Rust => Spec {
                 line_markers: &["//", "///", "//!"],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[Fence {
+                    open: "/*",
+                    close: "*/",
+                }],
             },
             Language::JavaScript => Spec {
                 line_markers: &["//"],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[Fence {
+                    open: "/*",
+                    close: "*/",
+                }],
             },
             Language::Java => Spec {
                 line_markers: &["//"],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[Fence {
+                    open: "/*",
+                    close: "*/",
+                }],
             },
             Language::Scala => Spec {
                 line_markers: &["//"],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[Fence {
+                    open: "/*",
+                    close: "*/",
+                }],
             },
             Language::C => Spec {
                 line_markers: &["//"],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[Fence {
+                    open: "/*",
+                    close: "*/",
+                }],
             },
             Language::Lua => Spec {
                 line_markers: &["--"],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[],
             },
             Language::SQL => Spec {
                 line_markers: &["--"],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[],
             },
             Language::Lisp => Spec {
                 line_markers: &[";;", ";"],
                 ignore_markers: &[],
                 fences: &[],
+                block_comments: &[],
             },
             Language::Markdown => Spec {
                 line_markers: &[],
                 ignore_markers: &["#", "- ", "* ", "+ ", "> ", "|"],
                 fences: &[
-                    Fence { open: "```", close: "```" },
-                    Fence { open: "~~~", close: "~~~" },
+                    Fence {
+                        open: "```",
+                        close: "```",
+                    },
+                    Fence {
+                        open: "~~~",
+                        close: "~~~",
+                    },
                 ],
+                block_comments: &[],
             },
         }
     }

--- a/src/reflow.rs
+++ b/src/reflow.rs
@@ -147,7 +147,7 @@ fn emit_paragraph(lines: &[&str], prefix: &str, opts: &Options, out: &mut String
 /// the "valid parentheses" pattern (LeetCode 20): push on an open
 /// marker, pop on the matching close, inspect the top to know the
 /// current enclosing region, but operate at line granularity.
-
+///
 /// Per call: O(k) where k is the number of configured fences (two
 /// for Markdown, zero for every other language). Amortized O(1).
 struct FenceStack<'a> {

--- a/src/source.rs
+++ b/src/source.rs
@@ -1,14 +1,14 @@
 //! Source-aware reflow: walk a source file line by line, pick out
-//! contiguous line-comment blocks, feed each block through
-//! [`reflow`], and copy every non-comment line through verbatim.
+//! contiguous line-comment runs and C-family block-comment regions,
+//! feed each region through [`reflow`], and copy every other line
+//! through verbatim.
 //!
-//! Block comments (`/* … */`, Python docstrings) are *not*
-//! recognised yet; they pass through as code. Line comments cover
-//! the prose in most modern codebases, and block comments have
-//! enough edge cases (string literals, nested delimiters,
-//! docstring vs string disambiguation) to warrant a real lexer.
+//! Python docstrings (`""" … """`) are *not* recognised yet — they
+//! are strings, not comments, and disambiguating a top-level
+//! docstring from `x = """..."""` needs a real lexer. Line and
+//! block comments cover the prose in most modern codebases.
 
-use crate::lang::{Language, Spec};
+use crate::lang::{Fence, Language, Spec};
 use crate::options::Options;
 use crate::reflow::reflow;
 
@@ -31,21 +31,28 @@ pub fn reflow_source(input: &str, language: Language, opts: &Options) -> String 
         return reflow(input, &opts);
     }
 
-    if spec.line_markers.is_empty() {
+    if spec.line_markers.is_empty() && spec.block_comments.is_empty() {
         return reflow(input, opts);
     }
 
+    // Splits input into lines, classifies each one as line-comment,
+    // block-comment-open, or code, gathers contiguous comment
+    // regions, reflows them, and pushes everything else back out
+    // unchanged.
     let lines: Vec<&str> = input.split_inclusive('\n').collect();
     let mut out = String::with_capacity(input.len());
     let mut i = 0;
     while i < lines.len() {
-        if is_comment_line(strip_newline(lines[i]), &spec) {
-            let start = i;
-            while i < lines.len() && is_comment_line(strip_newline(lines[i]), &spec) {
-                i += 1;
-            }
-            let block: String = lines[start..i].concat();
-            out.push_str(&reflow(&block, opts));
+        let stripped = strip_newline(lines[i]);
+
+        if is_line_comment(stripped, &spec) {
+            let end = end_of_line_comment_run(&lines, i, &spec);
+            out.push_str(&reflow(&lines[i..end].concat(), opts));
+            i = end;
+        } else if let Some(block) = find_block_comment_open(stripped, &spec) {
+            let end = end_of_block_comment(&lines, i, block);
+            out.push_str(&reflow(&lines[i..end].concat(), opts));
+            i = end;
         } else {
             out.push_str(lines[i]);
             i += 1;
@@ -54,12 +61,56 @@ pub fn reflow_source(input: &str, language: Language, opts: &Options) -> String 
     out
 }
 
-/// A line qualifies as a comment line when, after any leading
+/// A line qualifies as a line-comment line when, after any leading
 /// whitespace, its first non-whitespace run starts with one of
 /// the language's line-comment markers.
-fn is_comment_line(line: &str, spec: &Spec) -> bool {
+fn is_line_comment(line: &str, spec: &Spec) -> bool {
     let trimmed = line.trim_start();
     spec.line_markers.iter().any(|m| trimmed.starts_with(m))
+}
+
+/// Scan forward from `start` while lines keep qualifying as
+/// line-comments; return the exclusive end index of the run.
+fn end_of_line_comment_run(lines: &[&str], start: usize, spec: &Spec) -> usize {
+    let mut i = start;
+    while i < lines.len() && is_line_comment(strip_newline(lines[i]), spec) {
+        i += 1;
+    }
+    i
+}
+
+/// If `line` (after leading whitespace) starts with one of the
+/// language's block-comment opens, return the matching delimiter
+/// pair.
+fn find_block_comment_open(line: &str, spec: &Spec) -> Option<Fence> {
+    let trimmed = line.trim_start();
+    spec.block_comments
+        .iter()
+        .find(|b| trimmed.starts_with(b.open))
+        .copied()
+}
+
+/// Scan forward from `start` (a line that opens a block comment)
+/// until the matching close delimiter appears; return the
+/// exclusive end index of the region, including the closing line.
+/// Handles the single-line case (open and close on the same line)
+/// and an unterminated region (scans to end of input).
+fn end_of_block_comment(lines: &[&str], start: usize, block: Fence) -> usize {
+    let first = strip_newline(lines[start]);
+    let leading = first.len() - first.trim_start().len();
+    let after_open = &first[leading + block.open.len()..];
+    if after_open.contains(block.close) {
+        return start + 1;
+    }
+    let mut i = start + 1;
+    while i < lines.len() && !strip_newline(lines[i]).contains(block.close) {
+        i += 1;
+    }
+    if i < lines.len() {
+        i + 1
+    } else {
+        i
+    }
 }
 
 fn strip_newline(s: &str) -> &str {

--- a/tests/block_comments.rs
+++ b/tests/block_comments.rs
@@ -1,0 +1,54 @@
+use parfit::{reflow_source, Language, Options};
+
+#[test]
+fn rust_reflows_javadoc_style_block_comment() {
+    let src = "\
+pub struct Foo;
+
+/**
+ * This is a javadoc-style block comment that is deliberately much longer than the target width so that parfit has to reflow it across lines.
+ */
+impl Foo {}
+";
+    let out = reflow_source(src, Language::Rust, &Options::new(40));
+    assert!(out.contains("pub struct Foo;\n"));
+    assert!(out.contains("impl Foo {}\n"));
+    assert!(!out.contains(
+        "This is a javadoc-style block comment that is deliberately much longer than the target width"
+    ));
+    for line in out.lines() {
+        if line.trim_start().starts_with('*') {
+            assert!(line.chars().count() <= 40, "wrapped line too long: {line}");
+        }
+    }
+}
+
+#[test]
+fn go_passes_through_single_line_block_comment_context() {
+    let src = "\
+package main
+
+/* short */
+func main() {}
+";
+    let out = reflow_source(src, Language::Go, &Options::new(40));
+    assert!(out.contains("package main\n"));
+    assert!(out.contains("func main() {}\n"));
+}
+
+#[test]
+fn c_code_outside_block_comment_is_preserved() {
+    let src = "\
+int x = 42;
+/*
+ * A long enough comment that absolutely must reflow at a narrow width like thirty.
+ */
+int y = 7;
+";
+    let out = reflow_source(src, Language::C, &Options::new(30));
+    assert!(out.contains("int x = 42;\n"));
+    assert!(out.contains("int y = 7;\n"));
+    assert!(!out.contains(
+        "A long enough comment that absolutely must reflow at a narrow width like thirty."
+    ));
+}

--- a/tests/source.rs
+++ b/tests/source.rs
@@ -91,8 +91,14 @@ fn language_inferred_from_path_extension() {
     assert_eq!(Language::from_path(Path::new("z.cpp")), Language::C);
     assert_eq!(Language::from_path(Path::new("q.lua")), Language::Lua);
     assert_eq!(Language::from_path(Path::new("README")), Language::Text);
-    assert_eq!(Language::from_path(Path::new("notes.md")), Language::Markdown);
-    assert_eq!(Language::from_path(Path::new("notes.markdown")), Language::Markdown);
+    assert_eq!(
+        Language::from_path(Path::new("notes.md")),
+        Language::Markdown
+    );
+    assert_eq!(
+        Language::from_path(Path::new("notes.markdown")),
+        Language::Markdown
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Closes #9 for C-family languages (Go, Rust, JavaScript, Java, Scala, C/C++).

parfit now recognizes \`/* … */\` block comments in source files and reflows their contents as prose, leaving surrounding code byte-identical. Python docstrings (\`\"\"\" … \"\"\"\`) are still deferred — they are strings rather than comments and disambiguating \"\"\"foo\"\"\" at statement level from \"x = \"\"\"foo\"\"\"\" needs real lexing.

## Shape of the change

- \`Spec\` gains a \`block_comments: &[Fence]\` field. Same \`Fence\` type as Markdown code fences; the field name picks the treatment (reflow contents vs pass through verbatim). The 2x2 matrix is documented in the README under \"Prefix detection\".
- Source-mode walker in \`source.rs\` is split into caller-above-callee helpers: \`is_line_comment\`, \`end_of_line_comment_run\`, \`find_block_comment_open\`, \`end_of_block_comment\`. Main loop is three clauses, each a single line of work.

## Test plan

- [x] \`cargo test\` (existing + new block-comment tests)
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo fmt --all -- --check\`
- New integration tests cover: rust javadoc-style, go single-line block, c multi-line with surrounding code preserved