### PR TITLE
chore(lib): narrow public surface

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,12 +15,11 @@
 //!   reflow only the comment blocks and leave the code untouched.
 
 mod directives;
+mod lang;
+mod options;
 mod prefix;
 mod reflow;
 mod source;
-
-pub mod lang;
-pub mod options;
 
 pub use lang::Language;
 pub use options::Options;


### PR DESCRIPTION
## Summary

Demotes the \`lang\` and \`options\` modules from \`pub\` to private. The four items users actually consume — \`reflow\`, \`reflow_source\`, \`Language\`, \`Options\` — are re-exported at the crate root, so every sensible usage still works.

## Why

- Nothing in the tree reaches them by module path: \`grep parfit::lang parfit::options\` returns nothing.
- The internal types (\`Fence\`, \`Spec\`) are implementation detail. Exposing them means every future change to Spec is nominally breaking per cargo-semver-checks, without any downstream actually depending on the shape.
- Smaller API surface → fewer semver-breaks triggered by internal refactors, cleaner rustdoc, easier to reason about versioning.

## Test plan

- [x] \`cargo build\`
- [x] \`cargo clippy --all-targets -- -D warnings\`
- [x] \`cargo test\`