### PR TITLE
ci: wire RELEASE_PLZ_TOKEN and add brew install to README

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           command: release-pr
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   release:
@@ -40,14 +40,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
       - uses: dtolnay/rust-toolchain@stable
       - uses: release-plz/action@v0.5
         id: release
         with:
           command: release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PLZ_TOKEN || secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
       - name: Fast-forward rel to the released commit
         if: ${{ steps.release.outputs.releases_created == 'true' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ on:
   push:
     tags:
       - '**[0-9]+.[0-9]+.[0-9]+*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build (e.g. v0.4.1)'
+        required: true
 
 jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do

--- a/README
+++ b/README
@@ -15,8 +15,9 @@ Installation
 ============
 
     cargo install parfit
+    brew install caldempsey/parfit/parfit
 
-Installs a parfit binary on $PATH.
+Either installs a parfit binary on $PATH.
 
 
 Example


### PR DESCRIPTION
## Summary

Three one-line changes that unblock the cargo-dist → Homebrew pipeline:

1. **publish.yml uses \`RELEASE_PLZ_TOKEN\` (PAT) when set**, fallback to \`GITHUB_TOKEN\`. GitHub swallows workflow triggers on tags created with the default \`GITHUB_TOKEN\` (anti-loop protection), so release-plz's tag push never fires cargo-dist. With a PAT, tag pushes trigger cargo-dist and the full chain runs end-to-end.
2. **release.yml gets a \`workflow_dispatch\` trigger** so we can manually re-run cargo-dist against a specific tag if anything ever needs retrying.
3. **README adds the \`brew install caldempsey/parfit/parfit\` line** right under the \`cargo install parfit\` line.

## Test plan

- [ ] Merge this
- [ ] release-plz's pending PR gets updated / a new one opens for v0.4.2
- [ ] Merge that release PR
- [ ] Tag push fires cargo-dist (this time it will, because PAT)
- [ ] cargo-dist uploads 5 target tarballs + Homebrew formula
- [ ] \`brew install caldempsey/parfit/parfit\` works