### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/caldempsey/parfit/compare/v0.4.2...v0.4.3) - 2026-04-24
+
+### Fixed
+
+- *(ci)* revert manual workflow_dispatch on cargo-dist workflow
+
+### Other
+
+- *(releases)* rename CONTRIBUTING to RELEASES and document the flow
+
 ## [0.4.2](https://github.com/caldempsey/parfit/compare/v0.4.1...v0.4.2) - 2026-04-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -203,7 +203,7 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parfit"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "clap",
  "globset",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "parfit"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 authors = ["Callum Dempsey Leach"]
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `parfit`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/caldempsey/parfit/compare/v0.4.2...v0.4.3) - 2026-04-24

### Fixed

- *(ci)* revert manual workflow_dispatch on cargo-dist workflow

### Other

- *(releases)* rename CONTRIBUTING to RELEASES and document the flow
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).